### PR TITLE
next-prev should have width: 100%

### DIFF
--- a/src/assets/sass/_post.scss
+++ b/src/assets/sass/_post.scss
@@ -54,6 +54,7 @@ h3 {
 
 
 .next-prev {
+  width: 100%;
   display: inline-block;
 
   .prev {


### PR DESCRIPTION
Container needs to fully span its parent or else links might not appear all the way to
the left or right for first/last posts